### PR TITLE
Update PDN 5.2 branch for 3.13.2

### DIFF
--- a/3rd-party/includes/aom/aom_image.h
+++ b/3rd-party/includes/aom/aom_image.h
@@ -154,33 +154,17 @@ typedef enum aom_chroma_sample_position {
  *
  * While encoding, when metadata is added to an aom_image via
  * aom_img_add_metadata(), the flag passed along with the metadata will
- * determine where the metadata OBU will be placed in the encoded OBU stream,
- * and whether it's layer-specific. Metadata will be emitted into the output
- * stream within the next temporal unit if it satisfies the specified insertion
- * flag.
+ * determine where the metadata OBU will be placed in the encoded OBU stream.
+ * Metadata will be emitted into the output stream within the next temporal unit
+ * if it satisfies the specified insertion flag.
  *
- * If the video contains multiple spatial and/or temporal layers,
- * a layer-specific metadata OBU only applies to the current frame's layer, as
- * determined by the frame's temporal_id and spatial_id. Some metadata types
- * cannot be layer-specific, as listed in Section 6.7.1 of the draft AV1
- * specification as of 2025-03-06.
- *
- * During decoding, when the library encounters a metadata OBU, it is emitted
- * with the next output aom_image. Its insert_flag is set to either
- * AOM_MIF_ANY_FRAME, or AOM_MIF_ANY_FRAME_LAYER_SPECIFIC if the OBU contains an
- * OBU header extension (i.e. the video contains multiple layers AND the
- * metadata was added using *_LAYER_SPECIFC insert flag if using libaom).
+ * During decoding, when the library encounters a metadata OBU, it is always
+ * flagged as AOM_MIF_ANY_FRAME and emitted with the next output aom_image.
  */
 typedef enum aom_metadata_insert_flags {
-  AOM_MIF_NON_KEY_FRAME = 0, /**< Adds metadata if it's not a keyframe */
+  AOM_MIF_NON_KEY_FRAME = 0, /**< Adds metadata if it's not keyframe */
   AOM_MIF_KEY_FRAME = 1,     /**< Adds metadata only if it's a keyframe */
-  AOM_MIF_ANY_FRAME = 2,     /**< Adds metadata to any type of frame */
-  /** Adds layer-specific metadata if it's not a keyframe */
-  AOM_MIF_NON_KEY_FRAME_LAYER_SPECIFIC = 16,
-  /** Adds layer-specific metadata only if it's a keyframe */
-  AOM_MIF_KEY_FRAME_LAYER_SPECIFIC = 17,
-  /** Adds layer-specific metadata to any type of frame */
-  AOM_MIF_ANY_FRAME_LAYER_SPECIFIC = 18,
+  AOM_MIF_ANY_FRAME = 2      /**< Adds metadata to any type of frame */
 } aom_metadata_insert_flags_t;
 
 /*!\brief Array of aom_metadata structs for an image. */
@@ -284,55 +268,26 @@ aom_image_t *aom_img_alloc(aom_image_t *img, aom_img_fmt_t fmt,
  * storage for the image has been allocated elsewhere, and a descriptor is
  * desired to "wrap" that storage.
  *
- * \param[in]    img           Pointer to storage for descriptor. If this
- *                             parameter is NULL, the storage for the descriptor
- *                             will be allocated on the heap.
- * \param[in]    fmt           Format for the image
- * \param[in]    d_w           Width of the image. Must not exceed 0x08000000
- *                             (2^27).
- * \param[in]    d_h           Height of the image. Must not exceed 0x08000000
- *                             (2^27).
- * \param[in]    stride_align  Alignment, in bytes, of each row in the image
- *                             (stride). Must not exceed 65536.
- * \param[in]    img_data      Storage to use for the image. The storage must
- *                             outlive the returned image descriptor; it can be
- *                             disposed of after calling aom_img_free().
+ * \param[in]    img       Pointer to storage for descriptor. If this parameter
+ *                         is NULL, the storage for the descriptor will be
+ *                         allocated on the heap.
+ * \param[in]    fmt       Format for the image
+ * \param[in]    d_w       Width of the image. Must not exceed 0x08000000
+ *                         (2^27).
+ * \param[in]    d_h       Height of the image. Must not exceed 0x08000000
+ *                         (2^27).
+ * \param[in]    align     Alignment, in bytes, of each row in the image
+ *                         (stride). Must not exceed 65536.
+ * \param[in]    img_data  Storage to use for the image. The storage must
+ *                         outlive the returned image descriptor; it can be
+ *                         disposed of after calling aom_img_free().
  *
  * \return Returns a pointer to the initialized image descriptor. If the img
  *         parameter is non-null, the value of the img parameter will be
  *         returned.
- *
- * \note \a img_data is required to have a minimum allocation size that
- *       satisfies the requirements of the \a fmt, \a d_w, \a d_h and \a
- *       stride_align parameters. This size can be calculated as follows (see
- *       \c img_alloc_helper in the aom_image.c file in the libaom source tree
- *       for more detail):
- * \code
- * align = (1 << x_chroma_shift) - 1;
- * w = (d_w + align) & ~align;
- * align = (1 << y_chroma_shift) - 1;
- * h = (d_h + align) & ~align;
- *
- * s = (fmt & AOM_IMG_FMT_PLANAR) ? w : (uint64_t)bps * w / 8;
- * s = (fmt & AOM_IMG_FMT_HIGHBITDEPTH) ? s * 2 : s;
- * s = (s + stride_align - 1) & ~((uint64_t)stride_align - 1);
- * s = (fmt & AOM_IMG_FMT_HIGHBITDEPTH) ? s / 2 : s;
- * alloc_size = (fmt & AOM_IMG_FMT_PLANAR) ? (uint64_t)h * s * bps / 8
- *                                         : (uint64_t)h * s;
- * \endcode
- * \a x_chroma_shift, \a y_chroma_shift and \a bps can be obtained by calling
- * \ref aom_img_wrap with a non-\c NULL \a img_data parameter. The \c
- * aom_image_t pointer should \em not be used in other API calls until \em after
- * a successful call to \ref aom_img_wrap with a valid image buffer. For
- * example:
- * \code
- * aom_img_wrap(img, fmt, d_w, d_h, stride_align, (unsigned char *)1);
- * ... calculate buffer size and allocate buffer as desribed earlier
- * aom_img_wrap(img, fmt, d_w, d_h, stride_align, img_data);
- * \endcode
  */
 aom_image_t *aom_img_wrap(aom_image_t *img, aom_img_fmt_t fmt, unsigned int d_w,
-                          unsigned int d_h, unsigned int stride_align,
+                          unsigned int d_h, unsigned int align,
                           unsigned char *img_data);
 
 /*!\brief Open a descriptor, allocating storage for the underlying image with a

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020-2025 Nicholas Hayes
+Copyright (c) 2020-2026 Nicholas Hayes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Avif Container/AV1ConfigBoxBuilder.cs
+++ b/src/Avif Container/AV1ConfigBoxBuilder.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/AlphaChannelNames.cs
+++ b/src/Avif Container/Boxes/AlphaChannelNames.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/AvifBrands.cs
+++ b/src/Avif Container/Boxes/AvifBrands.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Box.cs
+++ b/src/Avif Container/Boxes/Box.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/BoxString.cs
+++ b/src/Avif Container/Boxes/BoxString.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/BoxTypes.cs
+++ b/src/Avif Container/Boxes/BoxTypes.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/CICPColorPrimaries.cs
+++ b/src/Avif Container/Boxes/Enums/CICPColorPrimaries.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/CICPMatrixCoefficients.cs
+++ b/src/Avif Container/Boxes/Enums/CICPMatrixCoefficients.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/CICPTransferCharacteristics.cs
+++ b/src/Avif Container/Boxes/Enums/CICPTransferCharacteristics.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/ChromaSamplePosition.cs
+++ b/src/Avif Container/Boxes/Enums/ChromaSamplePosition.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/ConstructionMethod.cs
+++ b/src/Avif Container/Boxes/Enums/ConstructionMethod.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/ImageMirrorDirection.cs
+++ b/src/Avif Container/Boxes/Enums/ImageMirrorDirection.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/ImageRotation.cs
+++ b/src/Avif Container/Boxes/Enums/ImageRotation.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/SequenceLevel.cs
+++ b/src/Avif Container/Boxes/Enums/SequenceLevel.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/SequenceProfile.cs
+++ b/src/Avif Container/Boxes/Enums/SequenceProfile.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Enums/StronglyTypedEnumeration.cs
+++ b/src/Avif Container/Boxes/Enums/StronglyTypedEnumeration.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/FileTypeBox.cs
+++ b/src/Avif Container/Boxes/FileTypeBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/FullBox.cs
+++ b/src/Avif Container/Boxes/FullBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/HandlerBox.cs
+++ b/src/Avif Container/Boxes/HandlerBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/IItemInfoEntry.cs
+++ b/src/Avif Container/Boxes/IItemInfoEntry.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/IItemReferenceEntry.cs
+++ b/src/Avif Container/Boxes/IItemReferenceEntry.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Info Entries/AV01ItemInfoEntryBox.cs
+++ b/src/Avif Container/Boxes/Item Info Entries/AV01ItemInfoEntryBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Info Entries/ExifItemInfoEntry.cs
+++ b/src/Avif Container/Boxes/Item Info Entries/ExifItemInfoEntry.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Info Entries/ImageGridItemInfoEntryBox.cs
+++ b/src/Avif Container/Boxes/Item Info Entries/ImageGridItemInfoEntryBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Info Entries/ItemInfoEntryFactory.cs
+++ b/src/Avif Container/Boxes/Item Info Entries/ItemInfoEntryFactory.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Info Entries/ItemInfoEntryTypes.cs
+++ b/src/Avif Container/Boxes/Item Info Entries/ItemInfoEntryTypes.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Info Entries/MimeItemInfoEntryBox.cs
+++ b/src/Avif Container/Boxes/Item Info Entries/MimeItemInfoEntryBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Info Entries/UriItemEntryInfoBox.cs
+++ b/src/Avif Container/Boxes/Item Info Entries/UriItemEntryInfoBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Info Entries/XMPItemInfoEntry.cs
+++ b/src/Avif Container/Boxes/Item Info Entries/XMPItemInfoEntry.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/AV1ConfigBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/AV1ConfigBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/AV1LayeredImageIndexingBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/AV1LayeredImageIndexingBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/AV1OperatingPointBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/AV1OperatingPointBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/AlphaChannelBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/AlphaChannelBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/AuxiliaryTypePropertyBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/AuxiliaryTypePropertyBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/Color Information/ColorInformationBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/Color Information/ColorInformationBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/Color Information/ColorInformationBoxTypes.cs
+++ b/src/Avif Container/Boxes/Item Properties/Color Information/ColorInformationBoxTypes.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/Color Information/IccProfileColorInformation.cs
+++ b/src/Avif Container/Boxes/Item Properties/Color Information/IccProfileColorInformation.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/Color Information/NclxColorInformation.cs
+++ b/src/Avif Container/Boxes/Item Properties/Color Information/NclxColorInformation.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/IItemProperty.cs
+++ b/src/Avif Container/Boxes/Item Properties/IItemProperty.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/ImageSpatialExtentsBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/ImageSpatialExtentsBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/ItemProperty.cs
+++ b/src/Avif Container/Boxes/Item Properties/ItemProperty.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/ItemPropertyFactory.cs
+++ b/src/Avif Container/Boxes/Item Properties/ItemPropertyFactory.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/ItemPropertyFull.cs
+++ b/src/Avif Container/Boxes/Item Properties/ItemPropertyFull.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/LayerSelectorBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/LayerSelectorBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/PixelAspectRatioBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/PixelAspectRatioBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/PixelInformationBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/PixelInformationBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/Transform/CleanApertureBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/Transform/CleanApertureBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/Transform/ImageMirrorBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/Transform/ImageMirrorBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Item Properties/Transform/ImageRotateBox.cs
+++ b/src/Avif Container/Boxes/Item Properties/Transform/ImageRotateBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemDataBox.cs
+++ b/src/Avif Container/Boxes/ItemDataBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemInfoBox.cs
+++ b/src/Avif Container/Boxes/ItemInfoBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemInfoEntryBox.cs
+++ b/src/Avif Container/Boxes/ItemInfoEntryBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemLocationBox.cs
+++ b/src/Avif Container/Boxes/ItemLocationBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemLocationEntry.cs
+++ b/src/Avif Container/Boxes/ItemLocationEntry.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemLocationExtent.cs
+++ b/src/Avif Container/Boxes/ItemLocationExtent.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemPropertiesBox.cs
+++ b/src/Avif Container/Boxes/ItemPropertiesBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemPropertyAssociationBox.cs
+++ b/src/Avif Container/Boxes/ItemPropertyAssociationBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemPropertyAssociationEntry.cs
+++ b/src/Avif Container/Boxes/ItemPropertyAssociationEntry.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemPropertyContainerBox.cs
+++ b/src/Avif Container/Boxes/ItemPropertyContainerBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemReferenceBox.cs
+++ b/src/Avif Container/Boxes/ItemReferenceBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ItemReferenceEntryBox.cs
+++ b/src/Avif Container/Boxes/ItemReferenceEntryBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/MediaDataBox.cs
+++ b/src/Avif Container/Boxes/MediaDataBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/MetaBox.cs
+++ b/src/Avif Container/Boxes/MetaBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/PrimaryItemBox.cs
+++ b/src/Avif Container/Boxes/PrimaryItemBox.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/Rational.cs
+++ b/src/Avif Container/Boxes/Rational.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/Boxes/ReferenceTypes.cs
+++ b/src/Avif Container/Boxes/ReferenceTypes.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/FourCC.cs
+++ b/src/Avif Container/FourCC.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/ImageGridDescriptor.cs
+++ b/src/Avif Container/ImageGridDescriptor.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/ImageGridInfo.cs
+++ b/src/Avif Container/ImageGridInfo.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/ImageGridMetadata.cs
+++ b/src/Avif Container/ImageGridMetadata.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Container/LayerSelectorInfo.cs
+++ b/src/Avif Container/LayerSelectorInfo.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/AlphaChannelUtil.cs
+++ b/src/Avif Reader/AlphaChannelUtil.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/AvifItemData.cs
+++ b/src/Avif Reader/AvifItemData.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/AvifParser.cs
+++ b/src/Avif Reader/AvifParser.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/AvifReader.cs
+++ b/src/Avif Reader/AvifReader.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/AvifReaderImage.cs
+++ b/src/Avif Reader/AvifReaderImage.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/AvifReaderImageFormat.cs
+++ b/src/Avif Reader/AvifReaderImageFormat.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/CICPColorData.cs
+++ b/src/Avif Reader/CICPColorData.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/DecoderImage.cs
+++ b/src/Avif Reader/DecoderImage.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/DecoderImageInfo.cs
+++ b/src/Avif Reader/DecoderImageInfo.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/DecoderLayerInfo.cs
+++ b/src/Avif Reader/DecoderLayerInfo.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/HDRFormat.cs
+++ b/src/Avif Reader/HDRFormat.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/IOutputImageTransform.cs
+++ b/src/Avif Reader/IOutputImageTransform.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/ImageTransform.cs
+++ b/src/Avif Reader/ImageTransform.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/ManagedAvifItemData.cs
+++ b/src/Avif Reader/ManagedAvifItemData.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Reader/UnmanagedAvifItemData.cs
+++ b/src/Avif Reader/UnmanagedAvifItemData.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Writer/AvifWriter.AvifWriterItem.cs
+++ b/src/Avif Writer/AvifWriter.AvifWriterItem.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Writer/AvifWriter.AvifWriterState.cs
+++ b/src/Avif Writer/AvifWriter.AvifWriterState.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Writer/AvifWriter.cs
+++ b/src/Avif Writer/AvifWriter.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Avif Writer/HomogeneousTileInfo.cs
+++ b/src/Avif Writer/HomogeneousTileInfo.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifFileType.cs
+++ b/src/AvifFileType.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifFileTypeFactory.cs
+++ b/src/AvifFileTypeFactory.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifLoad.cs
+++ b/src/AvifLoad.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifMetadata.cs
+++ b/src/AvifMetadata.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifMetadataNames.cs
+++ b/src/AvifMetadataNames.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative.cs
+++ b/src/AvifNative.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/AV1Decoder.cpp
+++ b/src/AvifNative/AV1Decoder.cpp
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/AV1Decoder.h
+++ b/src/AvifNative/AV1Decoder.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/AV1Encoder.cpp
+++ b/src/AvifNative/AV1Encoder.cpp
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/AV1Encoder.h
+++ b/src/AvifNative/AV1Encoder.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/AvifNative.cpp
+++ b/src/AvifNative/AvifNative.cpp
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/AvifNative.h
+++ b/src/AvifNative/AvifNative.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/CICPEnums.h
+++ b/src/AvifNative/CICPEnums.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/ChromaSubsampling.cpp
+++ b/src/AvifNative/ChromaSubsampling.cpp
@@ -4,7 +4,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/ChromaSubsampling.h
+++ b/src/AvifNative/ChromaSubsampling.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/DecodedImageConverter.cpp
+++ b/src/AvifNative/DecodedImageConverter.cpp
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/DecodedImageConverter.h
+++ b/src/AvifNative/DecodedImageConverter.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/ScopedAOMCodec.h
+++ b/src/AvifNative/ScopedAOMCodec.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/TargetVer.h
+++ b/src/AvifNative/TargetVer.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/YUVConversionHelpers.cpp
+++ b/src/AvifNative/YUVConversionHelpers.cpp
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/YUVConversionHelpers.h
+++ b/src/AvifNative/YUVConversionHelpers.h
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/AvifNative/version.rc
+++ b/src/AvifNative/version.rc
@@ -71,7 +71,7 @@ BEGIN
             VALUE "FileDescription", "AvifFileType native library"
             VALUE "FileVersion", "3.13.1.0"
             VALUE "InternalName", "AvifNative.dll"
-            VALUE "LegalCopyright", "Copyright (C) 2025 Nicholas Hayes"
+            VALUE "LegalCopyright", "Copyright (C) 2026 Nicholas Hayes"
             VALUE "OriginalFilename", "AvifNative.dll"
             VALUE "ProductName", "AvifFileType"
             VALUE "ProductVersion", "3.13.1.0"

--- a/src/AvifNative/version.rc
+++ b/src/AvifNative/version.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,13,1,0
- PRODUCTVERSION 3,13,1,0
+ FILEVERSION 3,13,2,0
+ PRODUCTVERSION 3,13,2,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "null54"
             VALUE "FileDescription", "AvifFileType native library"
-            VALUE "FileVersion", "3.13.1.0"
+            VALUE "FileVersion", "3.13.2.0"
             VALUE "InternalName", "AvifNative.dll"
             VALUE "LegalCopyright", "Copyright (C) 2026 Nicholas Hayes"
             VALUE "OriginalFilename", "AvifNative.dll"
             VALUE "ProductName", "AvifFileType"
-            VALUE "ProductVersion", "3.13.1.0"
+            VALUE "ProductVersion", "3.13.2.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/AvifSave.cs
+++ b/src/AvifSave.cs
@@ -115,7 +115,6 @@ namespace AvifFileType
             }
 
             ImageGridMetadata? imageGridMetadata = TryGetImageGridMetadata(document,
-                                                                           metadataFromLoad,
                                                                            options.encoderPreset,
                                                                            options.yuvFormat,
                                                                            preserveExistingTileSize);

--- a/src/AvifSave.cs
+++ b/src/AvifSave.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/BufferUtil.cs
+++ b/src/BufferUtil.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ColorContextUtil.cs
+++ b/src/ColorContextUtil.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/CompressedAV1Image.cs
+++ b/src/CompressedAV1Image.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/CompressedAV1ImageCollection.cs
+++ b/src/CompressedAV1ImageCollection.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Disposable.cs
+++ b/src/Disposable.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/EncoderPreset.cs
+++ b/src/EncoderPreset.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ExceptionUtil.cs
+++ b/src/ExceptionUtil.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/ExifColorSpace.cs
+++ b/src/Exif/ExifColorSpace.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/ExifParser.cs
+++ b/src/Exif/ExifParser.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/ExifValueCollection.cs
+++ b/src/Exif/ExifValueCollection.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/ExifValueTypeUtil.cs
+++ b/src/Exif/ExifValueTypeUtil.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/ExifWriter.cs
+++ b/src/Exif/ExifWriter.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/IFDEntry.cs
+++ b/src/Exif/IFDEntry.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/MetadataHelpers.cs
+++ b/src/Exif/MetadataHelpers.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/ReadOnlyListExtensions.cs
+++ b/src/Exif/ReadOnlyListExtensions.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Exif/TiffConstants.cs
+++ b/src/Exif/TiffConstants.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/IBitmapLockExtensions.cs
+++ b/src/IBitmapLockExtensions.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/Enums/ProfileClass.cs
+++ b/src/ICC Profile/Enums/ProfileClass.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/Enums/ProfileColorSpace.cs
+++ b/src/ICC Profile/Enums/ProfileColorSpace.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/Enums/ProfilePlatform.cs
+++ b/src/ICC Profile/Enums/ProfilePlatform.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/Numeric/S15Fixed16.cs
+++ b/src/ICC Profile/Numeric/S15Fixed16.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/Numeric/XYZNumber.cs
+++ b/src/ICC Profile/Numeric/XYZNumber.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/ProfileDateTime.cs
+++ b/src/ICC Profile/ProfileDateTime.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/ProfileHeader.cs
+++ b/src/ICC Profile/ProfileHeader.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/ProfileID.cs
+++ b/src/ICC Profile/ProfileID.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/ProfileSignature.cs
+++ b/src/ICC Profile/ProfileSignature.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/ProfileVersion.cs
+++ b/src/ICC Profile/ProfileVersion.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ICC Profile/RenderingIntent.cs
+++ b/src/ICC Profile/RenderingIntent.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/IO/BigEndianBinaryWriter.cs
+++ b/src/IO/BigEndianBinaryWriter.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/IO/EndianBinaryReader.cs
+++ b/src/IO/EndianBinaryReader.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/IO/EndianBinaryReaderSegment.cs
+++ b/src/IO/EndianBinaryReaderSegment.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/IO/Endianess.cs
+++ b/src/IO/Endianess.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/IO/StreamSegment.cs
+++ b/src/IO/StreamSegment.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/AvifNative_64.cs
+++ b/src/Interop/AvifNative_64.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/AvifNative_ARM64.cs
+++ b/src/Interop/AvifNative_ARM64.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/BitmapData.cs
+++ b/src/Interop/BitmapData.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/BitmapDataPixelFormat.cs
+++ b/src/Interop/BitmapDataPixelFormat.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/BooleanExtensions.cs
+++ b/src/Interop/BooleanExtensions.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/CICPColorDataMarshaller.cs
+++ b/src/Interop/CICPColorDataMarshaller.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/CompressedAV1Data.cs
+++ b/src/Interop/CompressedAV1Data.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/CompressedAV1DataAllocator.cs
+++ b/src/Interop/CompressedAV1DataAllocator.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/DecoderImageInfoMarshaller.cs
+++ b/src/Interop/DecoderImageInfoMarshaller.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/DecoderLayerInfoMarshaller.cs
+++ b/src/Interop/DecoderLayerInfoMarshaller.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/DecoderStatus.cs
+++ b/src/Interop/DecoderStatus.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/EncoderOptions.cs
+++ b/src/Interop/EncoderOptions.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/EncoderOptionsMarshaller.cs
+++ b/src/Interop/EncoderOptionsMarshaller.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/EncoderStatus.cs
+++ b/src/Interop/EncoderStatus.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/IPinnableBuffer.cs
+++ b/src/Interop/IPinnableBuffer.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/ManagedCompressedAV1Data.cs
+++ b/src/Interop/ManagedCompressedAV1Data.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/NativeOwnedAsciiString.cs
+++ b/src/Interop/NativeOwnedAsciiString.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/ProgressContext.cs
+++ b/src/Interop/ProgressContext.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/SafeDecoderImageHandle.cs
+++ b/src/Interop/SafeDecoderImageHandle.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/SafeNativeMemoryBuffer.cs
+++ b/src/Interop/SafeNativeMemoryBuffer.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Interop/UnmanagedCompressedAV1Data.cs
+++ b/src/Interop/UnmanagedCompressedAV1Data.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Localization/BuiltinStringResourceManager.cs
+++ b/src/Localization/BuiltinStringResourceManager.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Localization/IAvifStringResourceManager.cs
+++ b/src/Localization/IAvifStringResourceManager.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Localization/PdnLocalizedStringResourceManager.cs
+++ b/src/Localization/PdnLocalizedStringResourceManager.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/ObjectRefExtensions.cs
+++ b/src/ObjectRefExtensions.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/PluginSupportInfo.cs
+++ b/src/PluginSupportInfo.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.
@@ -22,7 +22,7 @@ using System.Runtime.Versioning;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("null54")]
 [assembly: AssemblyProduct("AvifFileType")]
-[assembly: AssemblyCopyright("Copyright © 2025 Nicholas Hayes (aka null54)")]
+[assembly: AssemblyCopyright("Copyright © 2026 Nicholas Hayes (aka null54)")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -46,5 +46,5 @@ using System.Runtime.Versioning;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13.1.0")]
-[assembly: AssemblyFileVersion("3.13.1.0")]
+[assembly: AssemblyVersion("3.13.2.0")]
+[assembly: AssemblyFileVersion("3.13.2.0")]

--- a/src/StreamExtensions.cs
+++ b/src/StreamExtensions.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.

--- a/src/YUVChromaSubsampling.cs
+++ b/src/YUVChromaSubsampling.cs
@@ -3,7 +3,7 @@
 // This file is part of pdn-avif, a FileType plugin for Paint.NET
 // that loads and saves AVIF images.
 //
-// Copyright (c) 2020-2025 Nicholas Hayes
+// Copyright (c) 2020-2026 Nicholas Hayes
 //
 // This file is licensed under the MIT License.
 // See LICENSE.txt for complete licensing and attribution information.


### PR DESCRIPTION
This also bumps the version to 3.13.2.1 (latest public version is 3.13.2.0)

There's also one little fix in `AvifSave.cs`. I'm not sure how that line of code got there. The version I built for 5.2 doesn't have that (looking at it via ILSpy), and it's a relic from when I was using the `MetadataForSaveOptions` for this instead of the custom metadata section. Maybe I accidentally pressed Undo on that one line of code before sending over that earlier PR.